### PR TITLE
Moved to EXTRACT stage

### DIFF
--- a/service_manifest.yml
+++ b/service_manifest.yml
@@ -6,7 +6,7 @@ description: >-
 accepts: audiovisual/flash|archive/audiovisual/flash
 rejects: empty|metadata/.*
 
-stage: CORE
+stage: EXTRACT
 category: Static Analysis
 
 file_required: true


### PR DESCRIPTION
submissions with archive/audiovisual/flash files yield Tags of Interest and Symbol results than at the CORE stage after Extract service is run.